### PR TITLE
Fix ndiaudiosrc offset

### DIFF
--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -375,9 +375,8 @@ impl BaseSrcImpl<BaseSrc> for NdiAudioSrc {
 
                 buffer.set_pts(pts + ndi_struct.start_pts);
                 buffer.set_duration(duration);
-                //TODO fix audio offset
                 buffer.set_offset(timestamp_data.offset);
-                timestamp_data.offset += 1;
+                timestamp_data.offset += audio_frame.no_samples as u64/audio_frame.no_channels as u64;
                 buffer.set_offset_end(timestamp_data.offset);
                 buffer.copy_from_slice(0, &vec).unwrap();
             }


### PR DESCRIPTION
A buffer can also have one or both of a start and an end offset. These are media-type specific. For video buffers, the start offset will generally be the frame number. For audio buffers, it will be the number of samples produced so far. For compressed data, it could be the byte offset in a source or destination file. Likewise, the end offset will be the offset of the end of the buffer. These can only be meaningfully interpreted if you know the media type of the buffer (the preceding CAPS event). Either or both can be set to GST_BUFFER_OFFSET_NONE.

https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/GstBuffer.html