### PR TITLE
FIX changed return for gstreamer functions, fixed NDI frames memory leaks

### DIFF
--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -311,7 +311,7 @@ impl ObjectSubclass for NdiAudioSrc {
 
             match settings.id_receiver {
                 0 => Err(gst_error_msg!(
-                gst::ResourceError::Settings,
+                gst::ResourceError::NotFound,
                 ["Could not connect to this source"]
             )),
                 _ => Ok(())

--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -309,7 +309,13 @@ impl ObjectSubclass for NdiAudioSrc {
                 &settings.stream_name.clone(),
             );
 
-            Ok(())
+            match settings.id_receiver {
+                0 => Err(gst_error_msg!(
+                gst::ResourceError::Settings,
+                ["Could not connect to this source"]
+            )),
+                _ => Ok(())
+            }
         }
 
         fn stop(&self, element: &gst_base::BaseSrc) -> Result<(), gst::ErrorMessage> {

--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -259,9 +259,9 @@ impl ObjectSubclass for NdiAudioSrc {
                 let audio_frame: NDIlib_audio_frame_v2_t = Default::default();
 
                 unsafe {
-                    while NDIlib_recv_capture_v2(pNDI_recv, ptr::null(), &audio_frame, ptr::null(), 1000) != NDIlib_frame_type_e::NDIlib_frame_type_audio {
-                        NDIlib_recv_free_audio_v2(pNDI_recv, &audio_frame);
-                    }
+                    while NDIlib_recv_capture_v2(pNDI_recv, ptr::null(), &audio_frame, ptr::null(), 1000)
+                        != NDIlib_frame_type_e::NDIlib_frame_type_audio {}
+                }
                     gst_debug!(self.cat, obj: element, "NDI audio frame received: {:?}", audio_frame);
 
                     if receiver.initial_timestamp <= audio_frame.timestamp as u64
@@ -269,7 +269,9 @@ impl ObjectSubclass for NdiAudioSrc {
                     {
                         receiver.initial_timestamp = audio_frame.timestamp as u64;
                     }
-                    NDIlib_recv_free_audio_v2(pNDI_recv, &audio_frame);
+                    unsafe {
+                        NDIlib_recv_free_audio_v2(pNDI_recv, &audio_frame);
+                    }
                     gst_debug!(self.cat, obj: element, "Setting initial timestamp to {}", receiver.initial_timestamp);
                 }
             }
@@ -357,8 +359,9 @@ impl ObjectSubclass for NdiAudioSrc {
             let audio_frame: NDIlib_audio_frame_v2_t = Default::default();
 
             unsafe {
-                while NDIlib_recv_capture_v2(pNDI_recv, ptr::null(), &audio_frame, ptr::null(), 1000) != NDIlib_frame_type_e::NDIlib_frame_type_audio {
-                    NDIlib_recv_free_audio_v2(pNDI_recv, &audio_frame);
+                unsafe {
+                    while NDIlib_recv_capture_v2(pNDI_recv, ptr::null(), &audio_frame, ptr::null(), 1000)
+                        != NDIlib_frame_type_e::NDIlib_frame_type_audio {}
                 }
             }
 

--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -420,7 +420,6 @@ impl ObjectSubclass for NdiAudioSrc {
                     if (frame_type == NDIlib_frame_type_e::NDIlib_frame_type_none && _settings.loss_threshold != 0)
                     || frame_type == NDIlib_frame_type_e::NDIlib_frame_type_error
                     {
-                        NDIlib_recv_free_audio_v2(pNDI_recv, &audio_frame);
                         if count_frame_none < _settings.loss_threshold{
                             count_frame_none += 1;
                             continue;
@@ -429,7 +428,6 @@ impl ObjectSubclass for NdiAudioSrc {
                         return Err(gst::FlowError::CustomError);
                     }
                     else if frame_type == NDIlib_frame_type_e::NDIlib_frame_type_none && _settings.loss_threshold == 0{
-                            NDIlib_recv_free_audio_v2(pNDI_recv, &audio_frame);
                             gst_debug!(self.cat, obj: element, "No audio frame received, sending empty buffer");
                             let buffer = gst::Buffer::with_size(0).unwrap();
                             return Ok(buffer)

--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -262,19 +262,17 @@ impl ObjectSubclass for NdiAudioSrc {
                     while NDIlib_recv_capture_v2(pNDI_recv, ptr::null(), &audio_frame, ptr::null(), 1000)
                         != NDIlib_frame_type_e::NDIlib_frame_type_audio {}
                 }
-                    gst_debug!(self.cat, obj: element, "NDI audio frame received: {:?}", audio_frame);
+                gst_debug!(self.cat, obj: element, "NDI audio frame received: {:?}", audio_frame);
 
-                    if receiver.initial_timestamp <= audio_frame.timestamp as u64
-                    || receiver.initial_timestamp == 0
-                    {
-                        receiver.initial_timestamp = audio_frame.timestamp as u64;
-                    }
-                    unsafe {
-                        NDIlib_recv_free_audio_v2(pNDI_recv, &audio_frame);
-                    }
-                    gst_debug!(self.cat, obj: element, "Setting initial timestamp to {}", receiver.initial_timestamp);
+                if receiver.initial_timestamp <= audio_frame.timestamp as u64
+                || receiver.initial_timestamp == 0 {
+                    receiver.initial_timestamp = audio_frame.timestamp as u64;
                 }
-            }
+                unsafe {
+                    NDIlib_recv_free_audio_v2(pNDI_recv, &audio_frame);
+                }
+                gst_debug!(self.cat, obj: element, "Setting initial timestamp to {}", receiver.initial_timestamp);
+                }
             self.parent_change_state(element, transition)
         }
     }
@@ -359,10 +357,8 @@ impl ObjectSubclass for NdiAudioSrc {
             let audio_frame: NDIlib_audio_frame_v2_t = Default::default();
 
             unsafe {
-                unsafe {
-                    while NDIlib_recv_capture_v2(pNDI_recv, ptr::null(), &audio_frame, ptr::null(), 1000)
-                        != NDIlib_frame_type_e::NDIlib_frame_type_audio {}
-                }
+                while NDIlib_recv_capture_v2(pNDI_recv, ptr::null(), &audio_frame, ptr::null(), 1000)
+                    != NDIlib_frame_type_e::NDIlib_frame_type_audio {}
             }
 
             let no_samples = audio_frame.no_samples as u64;

--- a/src/ndisys.rs
+++ b/src/ndisys.rs
@@ -33,6 +33,14 @@ extern "C" {
         p_metadata: *const NDIlib_metadata_frame_t,
         timeout_in_ms: u32,
     ) -> NDIlib_frame_type_e;
+    pub fn NDIlib_recv_free_video_v2(
+        p_instance: NDIlib_recv_instance_t,
+        p_video_data: *const NDIlib_video_frame_v2_t
+    );
+    pub fn NDIlib_recv_free_audio_v2(
+        p_instance: NDIlib_recv_instance_t,
+        p_audio_data: *const NDIlib_audio_frame_v2_t
+    );
 }
 
 pub type NDIlib_find_instance_t = *mut ::std::os::raw::c_void;

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -160,7 +160,7 @@ impl ObjectSubclass for NdiVideoSrc {
                 gst::PadDirection::Src,
                 gst::PadPresence::Always,
                 &caps,
-            );
+            ).unwrap();
             klass.add_pad_template(src_pad_template);
 
             klass.install_properties(&PROPERTIES);
@@ -295,7 +295,7 @@ impl ObjectSubclass for NdiVideoSrc {
     impl BaseSrcImpl for NdiVideoSrc {
         fn set_caps(&self, element: &gst_base::BaseSrc, caps: &gst::CapsRef) -> Result<(), gst::LoggableError> {
             let info = match gst_video::VideoInfo::from_caps(caps) {
-                None => return false,
+                None => return Err(gst_loggable_error!(self.cat, "Failed to build `VideoInfo` from caps {}", caps)),
                 Some(info) => info,
             };
             gst_debug!(self.cat, obj: element, "Configuring for caps {}", caps);
@@ -303,7 +303,7 @@ impl ObjectSubclass for NdiVideoSrc {
             let mut state = self.state.lock().unwrap();
             state.info = Some(info);
             let _ = element.post_message(&gst::Message::new_latency().src(Some(element)).build());
-            true
+            Ok(())
         }
 
         fn start(&self, element: &gst_base::BaseSrc) -> Result<(), gst::ErrorMessage> {
@@ -316,17 +316,18 @@ impl ObjectSubclass for NdiVideoSrc {
                 &settings.stream_name.clone(),
             );
 
-            settings.id_receiver != 0
+            // settings.id_receiver != 0
+            Ok(())
         }
 
         fn stop(&self, element: &gst_base::BaseSrc) -> Result<(), gst::ErrorMessage> {
-            *self.state.lock().unwrap() = Default::default();
+        *self.state.lock().unwrap() = Default::default();
 
             let settings = self.settings.lock().unwrap();
             stop_ndi(self.cat, element, settings.id_receiver);
             // Commented because when adding ndi destroy stopped in this line
             //*self.state.lock().unwrap() = Default::default();
-            true
+            Ok(())
         }
 
         fn query(&self, element: &gst_base::BaseSrc, query: &mut gst::QueryRef) -> bool {
@@ -349,7 +350,7 @@ impl ObjectSubclass for NdiVideoSrc {
                     return false;
                 }
             }
-            BaseSrcImpl::parent_query(self, element, query)
+            BaseSrcImplExt::parent_query(self, element, query)
         }
 
         fn fixate(&self, element: &gst_base::BaseSrc, caps: gst::Caps) -> gst::Caps {

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -319,7 +319,7 @@ impl ObjectSubclass for NdiVideoSrc {
             // settings.id_receiver != 0
             match settings.id_receiver {
                 0 => Err(gst_error_msg!(
-                gst::ResourceError::Settings,
+                gst::ResourceError::NotFound,
                 ["Could not connect to this source"]
             )),
                 _ => Ok(())

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -481,7 +481,6 @@ impl ObjectSubclass for NdiVideoSrc {
                     timestamp_data.offset += 1;
                     buffer.set_offset_end(timestamp_data.offset);
                     buffer.copy_from_slice(0, &vec).unwrap();
-                    // NDIlib_recv_free_video_v2(pNDI_recv, &video_frame);
                 }
 
                 gst_log!(self.cat, obj: element, "Produced buffer {:?}", buffer);

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -317,7 +317,13 @@ impl ObjectSubclass for NdiVideoSrc {
             );
 
             // settings.id_receiver != 0
-            Ok(())
+            match settings.id_receiver {
+                0 => Err(gst_error_msg!(
+                gst::ResourceError::Settings,
+                ["Could not connect to this source"]
+            )),
+                _ => Ok(())
+            }
         }
 
         fn stop(&self, element: &gst_base::BaseSrc) -> Result<(), gst::ErrorMessage> {

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -428,7 +428,6 @@ impl ObjectSubclass for NdiVideoSrc {
                     if (frame_type == NDIlib_frame_type_e::NDIlib_frame_type_none && _settings.loss_threshold != 0)
                     || frame_type == NDIlib_frame_type_e::NDIlib_frame_type_error
                     {
-                        NDIlib_recv_free_video_v2(pNDI_recv, &video_frame);
                         if count_frame_none < _settings.loss_threshold{
                             count_frame_none += 1;
                             continue;
@@ -437,7 +436,6 @@ impl ObjectSubclass for NdiVideoSrc {
                         return Err(gst::FlowError::CustomError);
                     }
                     else if frame_type == NDIlib_frame_type_e::NDIlib_frame_type_none && _settings.loss_threshold == 0{
-                            NDIlib_recv_free_video_v2(pNDI_recv, &video_frame);
                             gst_debug!(self.cat, obj: element, "No video frame received, sending empty buffer");
                             let buffer = gst::Buffer::with_size(0).unwrap();
                             return Ok(buffer)

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -268,9 +268,9 @@ impl ObjectSubclass for NdiVideoSrc {
                 let video_frame: NDIlib_video_frame_v2_t = Default::default();
 
                 unsafe {
-                    while NDIlib_recv_capture_v2(pNDI_recv, &video_frame, ptr::null(), ptr::null(), 1000) != NDIlib_frame_type_e::NDIlib_frame_type_video {
-                        NDIlib_recv_free_video_v2(pNDI_recv, &video_frame);
-                    }
+                while NDIlib_recv_capture_v2(pNDI_recv, &video_frame, ptr::null(), ptr::null(), 1000)
+                    != NDIlib_frame_type_e::NDIlib_frame_type_video {}
+                }
                     gst_debug!(self.cat, obj: element, "NDI video frame received: {:?}", video_frame);
 
                     if receiver.initial_timestamp <= video_frame.timestamp as u64
@@ -278,7 +278,9 @@ impl ObjectSubclass for NdiVideoSrc {
                     {
                         receiver.initial_timestamp = video_frame.timestamp as u64;
                     }
+                unsafe {
                     NDIlib_recv_free_video_v2(pNDI_recv, &video_frame);
+                }
                     gst_debug!(self.cat, obj: element, "Setting initial timestamp to {}", receiver.initial_timestamp);
                 }
             }
@@ -364,9 +366,8 @@ impl ObjectSubclass for NdiVideoSrc {
             let video_frame: NDIlib_video_frame_v2_t = Default::default();
 
             unsafe {
-                while NDIlib_recv_capture_v2(pNDI_recv, &video_frame, ptr::null(), ptr::null(), 1000) != NDIlib_frame_type_e::NDIlib_frame_type_video {
-                    NDIlib_recv_free_video_v2(pNDI_recv, &video_frame);
-                }
+                while NDIlib_recv_capture_v2(pNDI_recv, &video_frame, ptr::null(), ptr::null(), 1000)
+                    != NDIlib_frame_type_e::NDIlib_frame_type_video {}
             }
             settings.latency = gst::SECOND.mul_div_floor(
                 video_frame.frame_rate_D as u64,

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -268,8 +268,8 @@ impl ObjectSubclass for NdiVideoSrc {
                 let video_frame: NDIlib_video_frame_v2_t = Default::default();
 
                 unsafe {
-                while NDIlib_recv_capture_v2(pNDI_recv, &video_frame, ptr::null(), ptr::null(), 1000)
-                    != NDIlib_frame_type_e::NDIlib_frame_type_video {}
+                    while NDIlib_recv_capture_v2(pNDI_recv, &video_frame, ptr::null(), ptr::null(), 1000)
+                        != NDIlib_frame_type_e::NDIlib_frame_type_video {}
                 }
                     gst_debug!(self.cat, obj: element, "NDI video frame received: {:?}", video_frame);
 
@@ -278,12 +278,11 @@ impl ObjectSubclass for NdiVideoSrc {
                     {
                         receiver.initial_timestamp = video_frame.timestamp as u64;
                     }
-                unsafe {
-                    NDIlib_recv_free_video_v2(pNDI_recv, &video_frame);
-                }
+                    unsafe {
+                        NDIlib_recv_free_video_v2(pNDI_recv, &video_frame);
+                    }
                     gst_debug!(self.cat, obj: element, "Setting initial timestamp to {}", receiver.initial_timestamp);
                 }
-            }
             self.parent_change_state(element, transition)
         }
     }


### PR DESCRIPTION
Gstreamer must have changed plugins function return types for status_change, start, stop, change_caps from boolean to ErrorMessage or Result objects. I hope it's still compatible with 1.8

NDI frames must be freed with NDI_recv_free_audio/video as they are allocated within NDI C implementation, except when the memory is passed to gstreamer that does all the freeing.
