### PR TITLE
fix element register due to gstreamer rs update

### DIFF
--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -544,5 +544,5 @@ impl BaseSrcImpl for NdiAudioSrc {
 }
 
 pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
-    gst::Element::register(plugin, "ndiaudiosrc", 0, NdiAudioSrc::get_type())
+    gst::Element::register(Some(plugin), "ndiaudiosrc", 0, NdiAudioSrc::get_type())
 }

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -533,5 +533,5 @@ impl BaseSrcImpl for NdiVideoSrc {
 }
 
 pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
-    gst::Element::register(plugin, "ndivideosrc", 0, NdiVideoSrc::get_type())
+    gst::Element::register(Some(plugin), "ndivideosrc", 0, NdiVideoSrc::get_type())
 }


### PR DESCRIPTION
gst::Element::register changed it's prototype in the latest gstreamer-rs update.

This commit solves the following error:
```
error[E0308]: mismatched types
   --> src/ndiaudiosrc.rs:547:28
    |
547 |     gst::Element::register(plugin, "ndiaudiosrc", 0, NdiAudioSrc::get_type())
    |                            ^^^^^^
    |                            |
    |                            expected enum `std::option::Option`, found reference
    |                            help: try using a variant of the expected type: `Some(plugin)`
    |
    = note: expected type `std::option::Option<&gst::Plugin>`
               found type `&gst::Plugin`

error[E0308]: mismatched types
   --> src/ndivideosrc.rs:536:28
    |
536 |     gst::Element::register(plugin, "ndivideosrc", 0, NdiVideoSrc::get_type())
    |                            ^^^^^^
    |                            |
    |                            expected enum `std::option::Option`, found reference
    |                            help: try using a variant of the expected type: `Some(plugin)`
    |
    = note: expected type `std::option::Option<&gst::Plugin>`
               found type `&gst::Plugin`

error: aborting due to 2 previous errors

```