### PR TITLE
Never send an empty buffer but simply retry

### DIFF
--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -469,10 +469,10 @@ impl BaseSrcImpl for NdiVideoSrc {
                     gst_debug!(
                         self.cat,
                         obj: element,
-                        "No video frame received, sending empty buffer"
+                        "No video frame received, retry"
                     );
-                    let buffer = gst::Buffer::with_size(0).unwrap();
-                    return Ok(buffer);
+                    count_frame_none += 1;
+                    continue;
                 }
 
                 if time >= (video_frame.timestamp as u64) {


### PR DESCRIPTION
Sending an empty buffer will cause downstream to fail as it has the
wrong size.