### PR TITLE
Never return gst::FlowError::CustomError outside the element

### DIFF
--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -462,7 +462,7 @@ impl BaseSrcImpl for NdiAudioSrc {
                         continue;
                     }
                     gst_element_error!(element, gst::ResourceError::Read, ["NDI frame type none or error received, assuming that the source closed the stream...."]);
-                    return Err(gst::FlowError::CustomError);
+                    return Err(gst::FlowError::Error);
                 } else if frame_type == NDIlib_frame_type_e::NDIlib_frame_type_none
                     && _settings.loss_threshold == 0
                 {

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -462,7 +462,7 @@ impl BaseSrcImpl for NdiVideoSrc {
                         continue;
                     }
                     gst_element_error!(element, gst::ResourceError::Read, ["NDI frame type none or error received, assuming that the source closed the stream...."]);
-                    return Err(gst::FlowError::CustomError);
+                    return Err(gst::FlowError::Error);
                 } else if frame_type == NDIlib_frame_type_e::NDIlib_frame_type_none
                     && _settings.loss_threshold == 0
                 {


### PR DESCRIPTION
It's for internal-usage and must be converted to a normal error at the
boundary to the base classes.