### PR TITLE
Don't do anything in BaseSrc::negotiate()

### DIFF
--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -375,7 +375,13 @@ impl ElementImpl for NdiAudioSrc {
 }
 
 impl BaseSrcImpl for NdiAudioSrc {
-    fn unlock(&self, element: &gst_base::BaseSrc) -> std::result::Result<(), gst::ErrorMessage> {
+    fn negotiate(&self, _element: &gst_base::BaseSrc) -> Result<(), gst::LoggableError> {
+        // Always succeed here without doing anything: we will set the caps once we received a
+        // buffer, there's nothing we can negotiate
+        Ok(())
+    }
+
+    fn unlock(&self, element: &gst_base::BaseSrc) -> Result<(), gst::ErrorMessage> {
         gst_debug!(self.cat, obj: element, "Unlocking",);
         if let Some(ref controller) = *self.receiver_controller.lock().unwrap() {
             controller.set_flushing(true);
@@ -383,10 +389,7 @@ impl BaseSrcImpl for NdiAudioSrc {
         Ok(())
     }
 
-    fn unlock_stop(
-        &self,
-        element: &gst_base::BaseSrc,
-    ) -> std::result::Result<(), gst::ErrorMessage> {
+    fn unlock_stop(&self, element: &gst_base::BaseSrc) -> Result<(), gst::ErrorMessage> {
         gst_debug!(self.cat, obj: element, "Stop unlocking",);
         if let Some(ref controller) = *self.receiver_controller.lock().unwrap() {
             controller.set_flushing(false);

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -410,7 +410,13 @@ impl ElementImpl for NdiVideoSrc {
 }
 
 impl BaseSrcImpl for NdiVideoSrc {
-    fn unlock(&self, element: &gst_base::BaseSrc) -> std::result::Result<(), gst::ErrorMessage> {
+    fn negotiate(&self, _element: &gst_base::BaseSrc) -> Result<(), gst::LoggableError> {
+        // Always succeed here without doing anything: we will set the caps once we received a
+        // buffer, there's nothing we can negotiate
+        Ok(())
+    }
+
+    fn unlock(&self, element: &gst_base::BaseSrc) -> Result<(), gst::ErrorMessage> {
         gst_debug!(self.cat, obj: element, "Unlocking",);
         if let Some(ref controller) = *self.receiver_controller.lock().unwrap() {
             controller.set_flushing(true);
@@ -418,10 +424,7 @@ impl BaseSrcImpl for NdiVideoSrc {
         Ok(())
     }
 
-    fn unlock_stop(
-        &self,
-        element: &gst_base::BaseSrc,
-    ) -> std::result::Result<(), gst::ErrorMessage> {
+    fn unlock_stop(&self, element: &gst_base::BaseSrc) -> Result<(), gst::ErrorMessage> {
         gst_debug!(self.cat, obj: element, "Stop unlocking",);
         if let Some(ref controller) = *self.receiver_controller.lock().unwrap() {
             controller.set_flushing(false);


### PR DESCRIPTION
We can't negotiate anything meaningful with downstream and will always
set the caps based on the data we receive in ::create() later.