### PR TITLE
Depend on gstreamer 0.14.4 for gst::calculate_linear_regression()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,10 @@ edition = "2018"
 [dependencies]
 glib = { version = "0.8.0", features = ["subclassing"] }
 gobject-sys = "0.9"
-gstreamer = { version = "0.14.3", features = ["subclassing", "v1_12"] }
+gstreamer = { version = "0.14.4", features = ["subclassing", "v1_12"] }
 gstreamer-base = { version = "0.14.0", features = ["subclassing"] }
 gstreamer-audio = "0.14.0"
 gstreamer-video = { version = "0.14.3", features = ["v1_12"] }
-gstreamer-sys = "0.8"
 lazy_static = "1.1.0"
 byte-slice-cast = "0.2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use glib::prelude::*;
 extern crate gstreamer as gst;
 extern crate gstreamer_audio as gst_audio;
 extern crate gstreamer_base as gst_base;
-extern crate gstreamer_sys as gst_sys;
 extern crate gstreamer_video as gst_video;
 
 #[macro_use]


### PR DESCRIPTION
Instead of having our own unsafe binding for it.