### PR TITLE
Port to NDI SDK v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 GStreamer NDI Plugin for Linux
 ====================
 
-*Compiled and tested with Ubuntu 16.04.5, GStreamer 1.12 and NDI SDK 3.5.1*
+*Compiled and tested with NDI SDK 3.5, 3.8, 4.0 and 4.1*
 
 This is a plugin for the [GStreamer](https://gstreamer.freedesktop.org/) multimedia framework that allows GStreamer to receive a stream from a [NDI](https://www.newtek.com/ndi/) source. This plugin has been developed by [Teltek](http://teltek.es/) and was funded by the [University of the Arts London](https://www.arts.ac.uk/) and [The University of Manchester](https://www.manchester.ac.uk/).
 

--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -526,7 +526,7 @@ impl BaseSrcImpl for NdiAudioSrc {
                         );
                         gst::FlowError::NotNegotiated
                     })?;
-                    state.info = Some(info.clone());
+                    state.info = Some(info);
                     state.current_latency = buffer.get_duration();
                     drop(state);
                     gst_debug!(self.cat, obj: element, "Configuring for caps {}", caps);

--- a/src/ndiaudiosrc.rs
+++ b/src/ndiaudiosrc.rs
@@ -24,7 +24,6 @@ use crate::DEFAULT_RECEIVER_NDI_NAME;
 #[derive(Debug, Clone)]
 struct Settings {
     ndi_name: Option<String>,
-    ip_address: Option<String>,
     connect_timeout: u32,
     timeout: u32,
     receiver_ndi_name: String,
@@ -36,7 +35,6 @@ impl Default for Settings {
     fn default() -> Self {
         Settings {
             ndi_name: None,
-            ip_address: None,
             receiver_ndi_name: DEFAULT_RECEIVER_NDI_NAME.clone(),
             connect_timeout: 10000,
             timeout: 5000,
@@ -46,21 +44,12 @@ impl Default for Settings {
     }
 }
 
-static PROPERTIES: [subclass::Property; 7] = [
+static PROPERTIES: [subclass::Property; 6] = [
     subclass::Property("ndi-name", |name| {
         glib::ParamSpec::string(
             name,
             "NDI Name",
             "NDI stream name of the sender",
-            None,
-            glib::ParamFlags::READWRITE,
-        )
-    }),
-    subclass::Property("ip-address", |name| {
-        glib::ParamSpec::string(
-            name,
-            "IP Address",
-            "IP address and port of the sender, e.g. 127.0.0.1:5961",
             None,
             glib::ParamFlags::READWRITE,
         )
@@ -227,18 +216,6 @@ impl ObjectImpl for NdiAudioSrc {
                 );
                 settings.ndi_name = ndi_name;
             }
-            subclass::Property("ip-address", ..) => {
-                let mut settings = self.settings.lock().unwrap();
-                let ip_address = value.get().unwrap();
-                gst_debug!(
-                    self.cat,
-                    obj: basesrc,
-                    "Changing ip from {:?} to {:?}",
-                    settings.ip_address,
-                    ip_address,
-                );
-                settings.ip_address = ip_address;
-            }
             subclass::Property("receiver-ndi-name", ..) => {
                 let mut settings = self.settings.lock().unwrap();
                 let receiver_ndi_name = value.get().unwrap();
@@ -315,10 +292,6 @@ impl ObjectImpl for NdiAudioSrc {
             subclass::Property("ndi-name", ..) => {
                 let settings = self.settings.lock().unwrap();
                 Ok(settings.ndi_name.to_value())
-            }
-            subclass::Property("ip-address", ..) => {
-                let settings = self.settings.lock().unwrap();
-                Ok(settings.ip_address.to_value())
             }
             subclass::Property("receiver-ndi-name", ..) => {
                 let settings = self.settings.lock().unwrap();
@@ -401,18 +374,19 @@ impl BaseSrcImpl for NdiAudioSrc {
         *self.state.lock().unwrap() = Default::default();
         let settings = self.settings.lock().unwrap().clone();
 
-        if settings.ip_address.is_none() && settings.ndi_name.is_none() {
+        let ndi_name = if let Some(ref ndi_name) = settings.ndi_name {
+            ndi_name
+        } else {
             return Err(gst_error_msg!(
                 gst::LibraryError::Settings,
                 ["No IP address or NDI name given"]
             ));
-        }
+        };
 
         let receiver = connect_ndi(
             self.cat,
             element,
-            settings.ip_address.as_ref().map(String::as_str),
-            settings.ndi_name.as_ref().map(String::as_str),
+            ndi_name,
             &settings.receiver_ndi_name,
             settings.connect_timeout,
             settings.bandwidth,

--- a/src/ndisys.rs
+++ b/src/ndisys.rs
@@ -78,7 +78,7 @@ pub struct NDIlib_find_create_t {
 #[derive(Debug, Copy, Clone)]
 pub struct NDIlib_source_t {
     pub p_ndi_name: *const ::std::os::raw::c_char,
-    pub p_ip_address: *const ::std::os::raw::c_char,
+    pub p_url_address: *const ::std::os::raw::c_char,
 }
 
 #[repr(i32)]
@@ -107,21 +107,21 @@ pub enum NDIlib_recv_color_format_e {
     NDIlib_recv_color_format_RGBX_RGBA = 2,
     NDIlib_recv_color_format_UYVY_RGBA = 3,
     NDIlib_recv_color_format_fastest = 100,
+    NDIlib_recv_color_format_best = 101,
 }
 
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum NDIlib_FourCC_type_e {
-    NDIlib_FourCC_type_UYVY = 0x59_56_59_55,
-    NDIlib_FourCC_type_YV12 = 0x32_31_56_59,
-    NDIlib_FourCC_type_NV12 = 0x32_31_56_4e,
-    NDIlib_FourCC_type_I420 = 0x30_32_34_49,
-    NDIlib_FourCC_type_BGRA = 0x41_52_47_42,
-    NDIlib_FourCC_type_BGRX = 0x58_52_47_42,
-    NDIlib_FourCC_type_RGBA = 0x41_42_47_52,
-    NDIlib_FourCC_type_RGBX = 0x58_42_47_52,
-    NDIlib_FourCC_type_UYVA = 0x41_56_56_55,
-}
+pub type NDIlib_FourCC_video_type_e = u32;
+pub const NDIlib_FourCC_video_type_UYVY: NDIlib_FourCC_video_type_e = 0x59_56_59_55;
+pub const NDIlib_FourCC_video_type_UYVA: NDIlib_FourCC_video_type_e = 0x41_56_56_55;
+pub const NDIlib_FourCC_video_type_P216: NDIlib_FourCC_video_type_e = 0x36_31_32_50;
+pub const NDIlib_FourCC_video_type_PA16: NDIlib_FourCC_video_type_e = 0x36_31_41_50;
+pub const NDIlib_FourCC_video_type_YV12: NDIlib_FourCC_video_type_e = 0x32_31_56_59;
+pub const NDIlib_FourCC_video_type_I420: NDIlib_FourCC_video_type_e = 0x30_32_34_49;
+pub const NDIlib_FourCC_video_type_NV12: NDIlib_FourCC_video_type_e = 0x32_31_56_4e;
+pub const NDIlib_FourCC_video_type_BGRA: NDIlib_FourCC_video_type_e = 0x41_52_47_42;
+pub const NDIlib_FourCC_video_type_BGRX: NDIlib_FourCC_video_type_e = 0x58_52_47_42;
+pub const NDIlib_FourCC_video_type_RGBA: NDIlib_FourCC_video_type_e = 0x41_42_47_52;
+pub const NDIlib_FourCC_video_type_RGBX: NDIlib_FourCC_video_type_e = 0x58_42_47_52;
 
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -133,7 +133,6 @@ pub enum NDIlib_frame_format_type_e {
 }
 
 pub const NDIlib_send_timecode_synthesize: i64 = ::std::i64::MAX;
-pub const NDIlib_send_timecode_empty: i64 = 0;
 pub const NDIlib_recv_timestamp_undefined: i64 = ::std::i64::MAX;
 
 #[repr(C)]
@@ -143,7 +142,7 @@ pub struct NDIlib_recv_create_v3_t {
     pub color_format: NDIlib_recv_color_format_e,
     pub bandwidth: NDIlib_recv_bandwidth_e,
     pub allow_video_fields: bool,
-    pub p_ndi_name: *const ::std::os::raw::c_char,
+    pub p_ndi_recv_name: *const ::std::os::raw::c_char,
 }
 
 pub type NDIlib_recv_instance_t = *mut ::std::os::raw::c_void;
@@ -176,14 +175,14 @@ pub struct NDIlib_metadata_frame_t {
 pub struct NDIlib_video_frame_v2_t {
     pub xres: ::std::os::raw::c_int,
     pub yres: ::std::os::raw::c_int,
-    pub FourCC: NDIlib_FourCC_type_e,
+    pub FourCC: NDIlib_FourCC_video_type_e,
     pub frame_rate_N: ::std::os::raw::c_int,
     pub frame_rate_D: ::std::os::raw::c_int,
     pub picture_aspect_ratio: ::std::os::raw::c_float,
     pub frame_format_type: NDIlib_frame_format_type_e,
     pub timecode: i64,
     pub p_data: *const ::std::os::raw::c_char,
-    pub line_stride_in_bytes: ::std::os::raw::c_int,
+    pub line_stride_or_data_size_in_bytes: ::std::os::raw::c_int,
     pub p_metadata: *const ::std::os::raw::c_char,
     pub timestamp: i64,
 }
@@ -221,5 +220,5 @@ pub struct NDIlib_audio_frame_interleaved_16s_t {
     pub no_samples: ::std::os::raw::c_int,
     pub timecode: i64,
     pub reference_level: ::std::os::raw::c_int,
-    pub p_data: *mut ::std::os::raw::c_short,
+    pub p_data: *mut i16,
 }

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -25,7 +25,6 @@ use crate::DEFAULT_RECEIVER_NDI_NAME;
 #[derive(Debug, Clone)]
 struct Settings {
     ndi_name: Option<String>,
-    ip_address: Option<String>,
     connect_timeout: u32,
     timeout: u32,
     receiver_ndi_name: String,
@@ -37,7 +36,6 @@ impl Default for Settings {
     fn default() -> Self {
         Settings {
             ndi_name: None,
-            ip_address: None,
             receiver_ndi_name: DEFAULT_RECEIVER_NDI_NAME.clone(),
             connect_timeout: 10000,
             timeout: 5000,
@@ -47,21 +45,12 @@ impl Default for Settings {
     }
 }
 
-static PROPERTIES: [subclass::Property; 7] = [
+static PROPERTIES: [subclass::Property; 6] = [
     subclass::Property("ndi-name", |name| {
         glib::ParamSpec::string(
             name,
             "NDI Name",
             "NDI stream name of the sender",
-            None,
-            glib::ParamFlags::READWRITE,
-        )
-    }),
-    subclass::Property("ip-address", |name| {
-        glib::ParamSpec::string(
-            name,
-            "IP Address",
-            "IP address and port of the sender, e.g. 127.0.0.1:5961",
             None,
             glib::ParamFlags::READWRITE,
         )
@@ -262,18 +251,6 @@ impl ObjectImpl for NdiVideoSrc {
                 );
                 settings.ndi_name = ndi_name;
             }
-            subclass::Property("ip-address", ..) => {
-                let mut settings = self.settings.lock().unwrap();
-                let ip_address = value.get().unwrap();
-                gst_debug!(
-                    self.cat,
-                    obj: basesrc,
-                    "Changing ip from {:?} to {:?}",
-                    settings.ip_address,
-                    ip_address,
-                );
-                settings.ip_address = ip_address;
-            }
             subclass::Property("receiver-ndi-name", ..) => {
                 let mut settings = self.settings.lock().unwrap();
                 let receiver_ndi_name = value.get().unwrap();
@@ -350,10 +327,6 @@ impl ObjectImpl for NdiVideoSrc {
             subclass::Property("ndi-name", ..) => {
                 let settings = self.settings.lock().unwrap();
                 Ok(settings.ndi_name.to_value())
-            }
-            subclass::Property("ip-address", ..) => {
-                let settings = self.settings.lock().unwrap();
-                Ok(settings.ip_address.to_value())
             }
             subclass::Property("receiver-ndi-name", ..) => {
                 let settings = self.settings.lock().unwrap();
@@ -436,18 +409,19 @@ impl BaseSrcImpl for NdiVideoSrc {
         *self.state.lock().unwrap() = Default::default();
         let settings = self.settings.lock().unwrap().clone();
 
-        if settings.ip_address.is_none() && settings.ndi_name.is_none() {
+        let ndi_name = if let Some(ref ndi_name) = settings.ndi_name {
+            ndi_name
+        } else {
             return Err(gst_error_msg!(
                 gst::LibraryError::Settings,
                 ["No IP address or NDI name given"]
             ));
-        }
+        };
 
         let receiver = connect_ndi(
             self.cat,
             element,
-            settings.ip_address.as_ref().map(String::as_str),
-            settings.ndi_name.as_ref().map(String::as_str),
+            ndi_name,
             &settings.receiver_ndi_name,
             settings.connect_timeout,
             settings.bandwidth,

--- a/src/ndivideosrc.rs
+++ b/src/ndivideosrc.rs
@@ -565,7 +565,7 @@ impl BaseSrcImpl for NdiVideoSrc {
                         );
                         gst::FlowError::NotNegotiated
                     })?;
-                    state.info = Some(info.clone());
+                    state.info = Some(info);
                     state.current_latency = buffer.get_duration();
                     drop(state);
                     gst_debug!(self.cat, obj: element, "Configuring for caps {}", caps);

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -860,7 +860,7 @@ fn connect_ndi_async(
     if let Some(video) = video.and_then(|v| v.upgrade()).map(Receiver) {
         let mut video_recv = video.0.recv.lock().unwrap();
         assert!(video_recv.is_none());
-        *video_recv = Some(recv.clone());
+        *video_recv = Some(recv);
         video.0.recv_cond.notify_one();
     }
 
@@ -1264,7 +1264,7 @@ impl Receiver<VideoReceiver> {
         };
 
         let par = gst::Fraction::approximate_f32(video_frame.picture_aspect_ratio())
-            .unwrap_or(gst::Fraction::new(1, 1))
+            .unwrap_or_else(|| gst::Fraction::new(1, 1))
             * gst::Fraction::new(video_frame.yres(), video_frame.xres());
 
         #[cfg(feature = "interlaced-fields")]


### PR DESCRIPTION
    Most notably this allows the video line stride to be set to 0, in which
    case a default value is to be used, and it deprecates selecting NDI
    sources by their IP address and because of that we remove the relevant
    properties.
    
    Usually the SDK will give an URL instead of an IP address now, so usage
    would've been broken anyway.
