### PR TITLE
ndisrcdemux: Add no-more-pads signal

### DIFF
--- a/src/ndisrcdemux/imp.rs
+++ b/src/ndisrcdemux/imp.rs
@@ -276,6 +276,10 @@ impl NdiSrcDemux {
 
         if add_pad {
             element.add_pad(&srcpad).unwrap();
+            if element.num_src_pads() == 2 {
+                element.no_more_pads();
+            }
+
         }
 
         for ev in events {


### PR DESCRIPTION
Emit no-more-pads if we are adding the second pad of the element.